### PR TITLE
- small refactor, 'twitch' variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,11 +40,11 @@ func main() {
 	client.Join(twitchChannel)
 
 	// Connect to Twitch client
-	twitch := client.Connect()
+	err := client.Connect()
 
 	// If twitch errors, panic!
-	if twitch != nil {
-		panic(twitch)
+	if err != nil {
+		panic(err)
 	}
 
 }


### PR DESCRIPTION
- 'twitch' is already being used above, as it's the name of the library. The response from 'client.Connect()' is an error, so using this instead.